### PR TITLE
Create request

### DIFF
--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -199,7 +199,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
             }
             @Override
             public void onError(ErrorResponse errorResponse) {
-                promise.reject(errorResponse.getResponseBody());
+                String errorResponseBody = errorResponse.getResponseBody();
+                promise.reject(errorResponseBody.isEmpty() ? "unknown error" : errorResponseBody);
             }
         });
     }
@@ -219,7 +220,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
     
                     @Override
                     public void onError(ErrorResponse errorResponse) {
-                        promise.reject(errorResponse.getResponseBody());
+                        String errorResponseBody = errorResponse.getResponseBody();
+                        promise.reject(errorResponseBody.isEmpty() ? "unknown error" : errorResponseBody);
                     }
                 });      
         } catch (URISyntaxException e) {

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -194,8 +194,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
 
         provider.createRequest(request, new ZendeskCallback<Request>() {
             @Override
-            public void onSuccess(Request createRequest) {
-                promise.resolve("Ticket done!");
+            public void onSuccess(Request request) {
+                promise.resolve(request.getId());
             }
             @Override
             public void onError(ErrorResponse errorResponse) {

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -1,5 +1,11 @@
 package io.dcvz.rnzendesk;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.lang.Exception;
+
 import android.content.Intent;
 import android.os.Build;
 import androidx.annotation.RequiresApi;
@@ -11,6 +17,11 @@ import zendesk.core.JwtIdentity;
 import zendesk.core.AnonymousIdentity;
 import zendesk.core.PushRegistrationProvider;
 import zendesk.support.Support;
+import zendesk.support.CreateRequest;
+import zendesk.support.UploadProvider;
+import zendesk.support.UploadResponse;
+import zendesk.support.Request;
+import zendesk.support.RequestProvider;
 import zendesk.support.guide.HelpCenterActivity;
 import zendesk.support.request.RequestActivity;
 import zendesk.support.requestlist.RequestListActivity;
@@ -156,5 +167,47 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         getReactApplicationContext().startActivity(intent);
+    }
+
+    // MARK: - Ticket Methods
+    @ReactMethod
+    public void createTicket(String path) throws Exception {
+        final RequestProvider provider = Support.INSTANCE.provider().requestProvider();
+        final CreateRequest request = new CreateRequest();
+
+        request.setSubject("Ticket subject (Android)");
+        request.setDescription("Ticket description");
+
+        File fileToUpload = new File(new URL(path).toURI());
+        UploadProvider uploadProvider = Support.INSTANCE.provider().uploadProvider();
+
+
+        uploadProvider.uploadAttachment("screenshot.png", fileToUpload, "image/png",  new
+            ZendeskCallback<UploadResponse>() {
+                @Override
+                public void onSuccess(UploadResponse uploadResponse) {
+                    // Handle success
+                    List<String> attachmentsUploaded = new ArrayList<>();
+                    attachmentsUploaded.add(uploadResponse.getToken());
+                    request.setAttachments(attachmentsUploaded);
+                    provider.createRequest(request, new ZendeskCallback<Request>() {
+                        @Override
+                        public void onSuccess(Request createRequest) {
+                            // Handle the success
+                        }
+                        @Override
+                        public void onError(ErrorResponse errorResponse) {
+                            // Handle the error
+                            // Log the error
+                            // Logger.e("MyLogTag", errorResponse);
+                        }
+                    });
+                }
+
+                @Override
+                public void onError(ErrorResponse errorResponse) {
+                    // Handle error
+                }
+        });        
     }
 }

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -180,6 +180,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
         request.setSubject(subject);
         request.setDescription(desc);
 
+        // Need to pass upload tokens for any previously uploaded attachments
+        // (see the uploadAttachment method)
         ArrayList<String> attachmentsUploaded = new ArrayList<String>();
         for (int i = 0; i < attachments.size(); i++) {
             attachmentsUploaded.add(attachments.getString(i));
@@ -214,6 +216,10 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
                 ZendeskCallback<UploadResponse>() {
                     @Override
                     public void onSuccess(UploadResponse uploadResponse) {
+                        // When uploading an attachment to zendesk, we are given an
+                        // upload token in the response.
+                        // We need to pass this token when we make the request to
+                        // create a ticket
                         promise.resolve(uploadResponse.getToken());
                     }
     

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -201,7 +201,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
             }
             @Override
             public void onError(ErrorResponse errorResponse) {
-                promise.reject("Ticket creation failed");
+                String errorResponseBody = errorResponse.getResponseBody();
+                promise.reject(errorResponseBody.isEmpty() ? "unknown error" : errorResponseBody);
             }
         });
     }
@@ -225,7 +226,8 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
     
                     @Override
                     public void onError(ErrorResponse errorResponse) {
-                        promise.reject("Error uploading attachment");
+                        String errorResponseBody = errorResponse.getResponseBody();
+                        promise.reject(errorResponseBody.isEmpty() ? "unknown error" : errorResponseBody);
                     }
                 });      
         } catch (URISyntaxException e) {

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -173,7 +173,7 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
 
     // MARK: - Ticket Methods
     @ReactMethod
-    public void createTicket(String subject, String desc, ReadableArray attachments, final Promise promise) {
+    public void createTicket(String subject, String desc, ReadableArray tags, ReadableArray attachments, final Promise promise) {
         final RequestProvider provider = Support.INSTANCE.provider().requestProvider();
         final CreateRequest request = new CreateRequest();
 
@@ -185,6 +185,12 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
             attachmentsUploaded.add(attachments.getString(i));
         }
         request.setAttachments(attachmentsUploaded);
+        
+        ArrayList<String> tagsSelected = new ArrayList<String>();
+        for (int i = 0; i < tags.size(); i++) {
+            tagsSelected.add(tags.getString(i));
+        }
+        request.setTags(tagsSelected);
 
         provider.createRequest(request, new ZendeskCallback<Request>() {
             @Override

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -171,43 +171,56 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
 
     // MARK: - Ticket Methods
     @ReactMethod
-    public void createTicket(String path) throws Exception {
+    public void createTicket(String path, final Promise promise) throws Exception {
         final RequestProvider provider = Support.INSTANCE.provider().requestProvider();
         final CreateRequest request = new CreateRequest();
 
         request.setSubject("Ticket subject (Android)");
         request.setDescription("Ticket description");
 
-        File fileToUpload = new File(new URL(path).toURI());
-        UploadProvider uploadProvider = Support.INSTANCE.provider().uploadProvider();
+        provider.createRequest(request, new ZendeskCallback<Request>() {
+            @Override
+            public void onSuccess(Request createRequest) {
+                // Handle the success
+                promise.resolve("Ticket done!");
+            }
+            @Override
+            public void onError(ErrorResponse errorResponse) {
+                // Handle the error
+                // Log the error
+                // Logger.e("MyLogTag", errorResponse);
+                promise.reject("Ticket creation failed");
+            }
+        });
 
+        // File fileToUpload = new File(new URL(path).toURI());
+        // UploadProvider uploadProvider = Support.INSTANCE.provider().uploadProvider();
+        // uploadProvider.uploadAttachment("screenshot.png", fileToUpload, "image/png",  new
+        //     ZendeskCallback<UploadResponse>() {
+        //         @Override
+        //         public void onSuccess(UploadResponse uploadResponse) {
+        //             // Handle success
+        //             List<String> attachmentsUploaded = new ArrayList<>();
+        //             attachmentsUploaded.add(uploadResponse.getToken());
+        //             request.setAttachments(attachmentsUploaded);
+        //             provider.createRequest(request, new ZendeskCallback<Request>() {
+        //                 @Override
+        //                 public void onSuccess(Request createRequest) {
+        //                     // Handle the success
+        //                 }
+        //                 @Override
+        //                 public void onError(ErrorResponse errorResponse) {
+        //                     // Handle the error
+        //                     // Log the error
+        //                     // Logger.e("MyLogTag", errorResponse);
+        //                 }
+        //             });
+        //         }
 
-        uploadProvider.uploadAttachment("screenshot.png", fileToUpload, "image/png",  new
-            ZendeskCallback<UploadResponse>() {
-                @Override
-                public void onSuccess(UploadResponse uploadResponse) {
-                    // Handle success
-                    List<String> attachmentsUploaded = new ArrayList<>();
-                    attachmentsUploaded.add(uploadResponse.getToken());
-                    request.setAttachments(attachmentsUploaded);
-                    provider.createRequest(request, new ZendeskCallback<Request>() {
-                        @Override
-                        public void onSuccess(Request createRequest) {
-                            // Handle the success
-                        }
-                        @Override
-                        public void onError(ErrorResponse errorResponse) {
-                            // Handle the error
-                            // Log the error
-                            // Logger.e("MyLogTag", errorResponse);
-                        }
-                    });
-                }
-
-                @Override
-                public void onError(ErrorResponse errorResponse) {
-                    // Handle error
-                }
-        });        
+        //         @Override
+        //         public void onError(ErrorResponse errorResponse) {
+        //             // Handle error
+        //         }
+        // });        
     }
 }

--- a/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
+++ b/android/src/main/java/io/dcvz/rnzendesk/RNZendeskBridge.java
@@ -199,7 +199,7 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
             }
             @Override
             public void onError(ErrorResponse errorResponse) {
-                promise.reject("Ticket creation failed");
+                promise.reject(errorResponse.getResponseBody());
             }
         });
     }
@@ -219,7 +219,7 @@ public class RNZendeskBridge extends ReactContextBaseJavaModule {
     
                     @Override
                     public void onError(ErrorResponse errorResponse) {
-                        promise.reject("Error uploading attachment");
+                        promise.reject(errorResponse.getResponseBody());
                     }
                 });      
         } catch (URISyntaxException e) {

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -139,26 +139,33 @@ class RNZendesk: RCTEventEmitter {
     }
 
     // MARK: - Ticket Methods
-    @objc(createTicket)
-    func createTicket() {
+    @objc(createTicket:)
+    func createTicket(with path: String) {
+        print("Hello i am printing some stuff")
         DispatchQueue.main.async {
             var request = ZDKCreateRequest()
             request.subject = "I created a ticket!"
             request.requestDescription = "Created with the Zendesk SDK"
-            self.uploadAttachment { (attachment) in
+            self.uploadAttachment(path: path) { (attachment) in
                 if let attachment = attachment {
                     request.attachments.append(attachment)
                 }                
                 ZDKRequestProvider().createRequest(request) { (result, error) in
                     var lol = "ok"
+                    if let result = result {
+                        print("Create ticket result received")
+                    }
+                    if let error = error {
+                        print("Error: ", error.localizedDescription)
+                    }
                 }
             }
 
         }
     }
 
-    func uploadAttachment(callback: @escaping (ZDKUploadResponse?) -> Void) {
-        var theProfileImageUrl = URL(string: "https://media.glassdoor.com/sql/2448325/residently-squarelogo-1568749666426.png")
+    func uploadAttachment(path: String, callback: @escaping (ZDKUploadResponse?) -> Void) {
+        var theProfileImageUrl = URL(string: path)
         do {
             let attachment = try Data(contentsOf: theProfileImageUrl!)
             // let attachment = try Data(contentsOf: theProfileImageUrl as! URL)

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -139,17 +139,18 @@ class RNZendesk: RCTEventEmitter {
     }
 
     // MARK: - Ticket Methods
-    @objc(createTicket:desc:resolve:reject:)
-    func createTicket(with subject: String, desc: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(createTicket:desc:attachments:resolve:reject:)
+    func createTicket(with subject: String, desc: String, attachments: Array<String>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
             let request = ZDKCreateRequest()
             request.subject = subject
             request.requestDescription = desc
             
-            // TODO Attachments from tokens
-            // var uploadResponse = ZDKUploadResponse()
-            // uploadResponse.uploadToken = response.uploadToken!
-            // request.attachments.append(uploadResponse)
+            attachments.forEach { attachment in
+                var uploadResponse = ZDKUploadResponse()
+                uploadResponse.uploadToken = attachment
+                request.attachments.append(uploadResponse)
+            }
 
             ZDKRequestProvider().createRequest(request) { (result, error) in
                 // TODO resolve and reject in a meaningful way (iOS should match android on this)
@@ -168,6 +169,7 @@ class RNZendesk: RCTEventEmitter {
 
     @objc(uploadAttachment:mimeType:fileName:resolve:reject:)
     func uploadAttachment(path: String, mimeType: String, fileName: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        // TODO wrap in DispatchQueue.main.async
         let theProfileImageUrl = URL(string: "file://" + path)
         do {
             let attachment = try Data(contentsOf: theProfileImageUrl!)
@@ -184,6 +186,7 @@ class RNZendesk: RCTEventEmitter {
             }
         } catch {
             print("Unable to load data: \(error)")
+            // TODO reject
         }
     }
 }

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -139,28 +139,40 @@ class RNZendesk: RCTEventEmitter {
     }
 
     // MARK: - Ticket Methods
-    @objc(createTicket:)
-    func createTicket(with path: String) {
+    @objc(createTicket:resolve:reject:)
+    func createTicket(with path: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         print("Hello i am printing some stuff")
         NSLog("hello this is a log")
         DispatchQueue.main.async {
             var request = ZDKCreateRequest()
             request.subject = "I created a ticket!"
             request.requestDescription = "Created with the Zendesk SDK"
-            self.uploadAttachment(path: path) { (attachment) in
-                if let attachment = attachment {
-                    request.attachments.append(attachment)
-                }                
-                ZDKRequestProvider().createRequest(request) { (result, error) in
-                    var lol = "ok"
-                    if let result = result {
-                        print("Create ticket result received")
-                    }
-                    if let error = error {
-                        print("Error: ", error.localizedDescription)
-                    }
+
+            ZDKRequestProvider().createRequest(request) { (result, error) in
+                var lol = "ok"
+                if let result = result {
+                    print("Create ticket result received")
+                    resolve("Create ticket result received")
+                }
+                if let error = error {
+                    print("Error: ", error.localizedDescription)
                 }
             }
+
+            // self.uploadAttachment(path: path) { (attachment) in
+            //     if let attachment = attachment {
+            //         request.attachments.append(attachment)
+            //     }                
+            //     ZDKRequestProvider().createRequest(request) { (result, error) in
+            //         var lol = "ok"
+            //         if let result = result {
+            //             print("Create ticket result received")
+            //         }
+            //         if let error = error {
+            //             print("Error: ", error.localizedDescription)
+            //         }
+            //     }
+            // }
 
         }
     }

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -142,6 +142,7 @@ class RNZendesk: RCTEventEmitter {
     @objc(createTicket:)
     func createTicket(with path: String) {
         print("Hello i am printing some stuff")
+        NSLog("hello this is a log")
         DispatchQueue.main.async {
             var request = ZDKCreateRequest()
             request.subject = "I created a ticket!"
@@ -165,10 +166,10 @@ class RNZendesk: RCTEventEmitter {
     }
 
     func uploadAttachment(path: String, callback: @escaping (ZDKUploadResponse?) -> Void) {
-        var theProfileImageUrl = URL(string: path)
+        print("uploadAttachment: " + path)
+        var theProfileImageUrl = URL(string: "file://" + path)
         do {
             let attachment = try Data(contentsOf: theProfileImageUrl!)
-            // let attachment = try Data(contentsOf: theProfileImageUrl as! URL)
             // TODO MIME TYPE
             ZDKUploadProvider().uploadAttachment(attachment, withFilename: "image_name_app.png", andContentType: "image/png") { (response, error) in
                 if let response = response {

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -147,6 +147,8 @@ class RNZendesk: RCTEventEmitter {
             request.requestDescription = desc
             request.tags = tags
             
+            // Need to pass upload tokens for any previously uploaded attachments
+            // (see the uploadAttachment method)
             attachments.forEach { attachment in
                 var uploadResponse = ZDKUploadResponse()
                 uploadResponse.uploadToken = attachment
@@ -184,6 +186,10 @@ class RNZendesk: RCTEventEmitter {
                 ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
                     // TODO resolve and reject in a meaningful way (iOS should match android on this)
                     if let response = response {
+                        // When uploading an attachment to zendesk, we are given an
+                        // upload token in the response.
+                        // We need to pass this token when we make the request to
+                        // create a ticket
                         resolve(response.uploadToken!)
                     } else if let error = error {
                         reject("zendesk_error", error.localizedDescription, error);

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -137,4 +137,43 @@ class RNZendesk: RCTEventEmitter {
             UIApplication.shared.keyWindow?.rootViewController?.present(nvc, animated: true)
         }
     }
+
+    // MARK: - Ticket Methods
+    @objc(createTicket)
+    func createTicket() {
+        DispatchQueue.main.async {
+            var request = ZDKCreateRequest()
+            request.subject = "I created a ticket!"
+            request.requestDescription = "Created with the Zendesk SDK"
+            self.uploadAttachment { (attachment) in
+                if let attachment = attachment {
+                    request.attachments.append(attachment)
+                }                
+                ZDKRequestProvider().createRequest(request) { (result, error) in
+                    var lol = "ok"
+                }
+            }
+
+        }
+    }
+
+    func uploadAttachment(callback: @escaping (ZDKUploadResponse?) -> Void) {
+        var theProfileImageUrl = URL(string: "https://media.glassdoor.com/sql/2448325/residently-squarelogo-1568749666426.png")
+        do {
+            let attachment = try Data(contentsOf: theProfileImageUrl!)
+            // let attachment = try Data(contentsOf: theProfileImageUrl as! URL)
+            ZDKUploadProvider().uploadAttachment(attachment, withFilename: "image_name_app.png", andContentType: "image") { (response, error) in
+                if let response = response {
+                    print("Token: ", response.uploadToken!)
+                    print("Attachment: ", response.attachment!)
+                }
+                if let error = error {
+                    print("Error: ", error.localizedDescription)
+                }
+                callback(response)  // response always gets sent regardless if nil.
+            }
+        } catch {
+            print("Unable to load data: \(error)")
+        }
+    }
 }

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -139,12 +139,13 @@ class RNZendesk: RCTEventEmitter {
     }
 
     // MARK: - Ticket Methods
-    @objc(createTicket:desc:attachments:resolve:reject:)
-    func createTicket(with subject: String, desc: String, attachments: Array<String>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(createTicket:desc:tags:attachments:resolve:reject:)
+    func createTicket(with subject: String, desc: String, tags: Array<String>, attachments: Array<String>, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
             let request = ZDKCreateRequest()
             request.subject = subject
             request.requestDescription = desc
+            request.tags = tags
             
             attachments.forEach { attachment in
                 var uploadResponse = ZDKUploadResponse()

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -169,24 +169,25 @@ class RNZendesk: RCTEventEmitter {
 
     @objc(uploadAttachment:mimeType:fileName:resolve:reject:)
     func uploadAttachment(path: String, mimeType: String, fileName: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        // TODO wrap in DispatchQueue.main.async
-        let theProfileImageUrl = URL(string: "file://" + path)
-        do {
-            let attachment = try Data(contentsOf: theProfileImageUrl!)
-            ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
-                // TODO resolve and reject in a meaningful way (iOS should match android on this)
-                if let response = response {
-                    resolve(response.uploadToken!)
-                } else if let error = error {
-                    reject("zendesk_error", error.localizedDescription, error);
-                } else {
-                    let unKnownError = NSError(domain: "", code: 200, userInfo: nil)
-                    reject("unknown_error", "Unexpected error", unKnownError)
+        DispatchQueue.main.async {
+            let theProfileImageUrl = URL(string: "file://" + path)
+            do {
+                let attachment = try Data(contentsOf: theProfileImageUrl!)
+                ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
+                    // TODO resolve and reject in a meaningful way (iOS should match android on this)
+                    if let response = response {
+                        resolve(response.uploadToken!)
+                    } else if let error = error {
+                        reject("zendesk_error", error.localizedDescription, error);
+                    } else {
+                        let unKnownError = NSError(domain: "", code: 200, userInfo: nil)
+                        reject("unexpected_error", "Unexpected error", unKnownError)
+                    }
                 }
+            } catch {
+                print("Unable to load data: \(error)")
+                reject("unknown_error", "Unknown error", error)
             }
-        } catch {
-            print("Unable to load data: \(error)")
-            // TODO reject
         }
     }
 }

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -184,7 +184,6 @@ class RNZendesk: RCTEventEmitter {
             do {
                 let attachment = try Data(contentsOf: theProfileImageUrl!)
                 ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
-                    // TODO resolve and reject in a meaningful way (iOS should match android on this)
                     if let response = response {
                         // When uploading an attachment to zendesk, we are given an
                         // upload token in the response.

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -162,7 +162,8 @@ class RNZendesk: RCTEventEmitter {
         do {
             let attachment = try Data(contentsOf: theProfileImageUrl!)
             // let attachment = try Data(contentsOf: theProfileImageUrl as! URL)
-            ZDKUploadProvider().uploadAttachment(attachment, withFilename: "image_name_app.png", andContentType: "image") { (response, error) in
+            // TODO MIME TYPE
+            ZDKUploadProvider().uploadAttachment(attachment, withFilename: "image_name_app.png", andContentType: "image/png") { (response, error) in
                 if let response = response {
                     print("Token: ", response.uploadToken!)
                     print("Attachment: ", response.attachment!)

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -139,12 +139,12 @@ class RNZendesk: RCTEventEmitter {
     }
 
     // MARK: - Ticket Methods
-    @objc(createTicket:resolve:reject:)
-    func createTicket(with path: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc(createTicket:desc:resolve:reject:)
+    func createTicket(with subject: String, desc: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         DispatchQueue.main.async {
             let request = ZDKCreateRequest()
-            request.subject = "I created a ticket!"
-            request.requestDescription = "Created with the Zendesk SDK"
+            request.subject = subject
+            request.requestDescription = desc
             
             // TODO Attachments from tokens
             // var uploadResponse = ZDKUploadResponse()

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -141,10 +141,8 @@ class RNZendesk: RCTEventEmitter {
     // MARK: - Ticket Methods
     @objc(createTicket:resolve:reject:)
     func createTicket(with path: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        print("Hello i am printing some stuff")
-        NSLog("hello this is a log")
         DispatchQueue.main.async {
-            var request = ZDKCreateRequest()
+            let request = ZDKCreateRequest()
             request.subject = "I created a ticket!"
             request.requestDescription = "Created with the Zendesk SDK"
             
@@ -153,62 +151,35 @@ class RNZendesk: RCTEventEmitter {
             // uploadResponse.uploadToken = response.uploadToken!
             // request.attachments.append(uploadResponse)
 
-
             ZDKRequestProvider().createRequest(request) { (result, error) in
-                var lol = "ok"
-                if let result = result {
-                    print("Create ticket result received")
+                // TODO resolve and reject in a meaningful way (iOS should match android on this)
+                // if let result = result {
+                if result != nil {
                     resolve("Create ticket result received")
-                }
-                if let error = error {
-                    print("Error: ", error.localizedDescription)
+                } else if let error = error {
+                    reject("zendesk_error", error.localizedDescription, error);
+                } else {
+                    let unKnownError = NSError(domain: "", code: 200, userInfo: nil)
+                    reject("unknown_error", "Unexpected error", unKnownError)
                 }
             }
-
-            // self.uploadAttachment(path: path) { (attachment) in
-            //     if let attachment = attachment {
-            //         request.attachments.append(attachment)
-            //     }                
-            //     ZDKRequestProvider().createRequest(request) { (result, error) in
-            //         var lol = "ok"
-            //         if let result = result {
-            //             print("Create ticket result received")
-            //         }
-            //         if let error = error {
-            //             print("Error: ", error.localizedDescription)
-            //         }
-            //     }
-            // }
-
         }
     }
 
     @objc(uploadAttachment:mimeType:fileName:resolve:reject:)
     func uploadAttachment(path: String, mimeType: String, fileName: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        print("uploadAttachment: " + path)
-        var theProfileImageUrl = URL(string: "file://" + path)
+        let theProfileImageUrl = URL(string: "file://" + path)
         do {
             let attachment = try Data(contentsOf: theProfileImageUrl!)
-            // TODO MIME TYPE
             ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
+                // TODO resolve and reject in a meaningful way (iOS should match android on this)
                 if let response = response {
-                    print("Token: ", response.uploadToken!)
-                    print("Attachment: ", response.attachment!)
-                    // resolve(response.attachment)
-                    var request = ZDKCreateRequest()
-                    request.subject = "I created a ticket!"
-                    request.requestDescription = "Created with the Zendesk SDK"
-                    var uploadResponse = ZDKUploadResponse()
-                    uploadResponse.uploadToken = response.uploadToken!
-                    request.attachments.append(uploadResponse)
-                    ZDKRequestProvider().createRequest(request) { (result, error) in 
-                        var lol = "ok"
-                    }
                     resolve(response.uploadToken!)
-                }
-                if let error = error {
-                    print("Error: ", error.localizedDescription)
-                    // reject(error.localizedDescription)
+                } else if let error = error {
+                    reject("zendesk_error", error.localizedDescription, error);
+                } else {
+                    let unKnownError = NSError(domain: "", code: 200, userInfo: nil)
+                    reject("unknown_error", "Unexpected error", unKnownError)
                 }
             }
         } catch {

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -154,10 +154,17 @@ class RNZendesk: RCTEventEmitter {
             }
 
             ZDKRequestProvider().createRequest(request) { (result, error) in
-                // TODO resolve and reject in a meaningful way (iOS should match android on this)
-                // if let result = result {
                 if result != nil {
-                    resolve("Create ticket result received")
+                    let result_object = result as AnyObject?
+                    let resp_data = result_object?.data as Data?
+                    do {
+                        let json = try (JSONSerialization.jsonObject(with: resp_data!)) as? [String:Any]
+                        let request_obj = json!["request"] as? [String:Any]
+                        resolve(request_obj!["id"])
+                    }
+                    catch {
+                        reject("zendesk_error", "Error parsing JSON response", error)
+                    }
                 } else if let error = error {
                     reject("zendesk_error", error.localizedDescription, error);
                 } else {

--- a/ios/RNZendesk/RNZendesk.swift
+++ b/ios/RNZendesk/RNZendesk.swift
@@ -182,7 +182,6 @@ class RNZendesk: RCTEventEmitter {
             do {
                 let attachment = try Data(contentsOf: theProfileImageUrl!)
                 ZDKUploadProvider().uploadAttachment(attachment, withFilename: fileName, andContentType: mimeType) { (response, error) in
-                    // TODO resolve and reject in a meaningful way (iOS should match android on this)
                     if let response = response {
                         resolve(response.uploadToken!)
                     } else if let error = error {

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -33,4 +33,7 @@ RCT_EXTERN_METHOD(showTicket:(NSString *)requestId);
 RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTResponseSenderBlock)resultCallback);
 RCT_EXTERN_METHOD(showTicketList);
 
+// MARK: - Ticket Methods
+RCT_EXTERN_METHOD(createTicket)
+
 @end

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -34,6 +34,6 @@ RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTRespons
 RCT_EXTERN_METHOD(showTicketList);
 
 // MARK: - Ticket Methods
-RCT_EXTERN_METHOD(createTicket:(NSString *)path)
+RCT_EXTERN_METHOD(createTicket:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 @end

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -34,7 +34,7 @@ RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTRespons
 RCT_EXTERN_METHOD(showTicketList);
 
 // MARK: - Ticket Methods
-RCT_EXTERN_METHOD(createTicket:(NSString *)subject desc:(NSString *)desc resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(createTicket:(NSString *)subject desc:(NSString *)desc attachments:(NSArray)attachments resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(uploadAttachment:(NSString *)path mimeType:(NSString *)mimeType fileName:(NSString *)file resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -34,6 +34,6 @@ RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTRespons
 RCT_EXTERN_METHOD(showTicketList);
 
 // MARK: - Ticket Methods
-RCT_EXTERN_METHOD(createTicket)
+RCT_EXTERN_METHOD(createTicket:(NSString *)path)
 
 @end

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -36,4 +36,6 @@ RCT_EXTERN_METHOD(showTicketList);
 // MARK: - Ticket Methods
 RCT_EXTERN_METHOD(createTicket:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
+RCT_EXTERN_METHOD(uploadAttachment:(NSString *)path mimeType:(NSString *)mimeType fileName:(NSString *)file resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -34,7 +34,7 @@ RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTRespons
 RCT_EXTERN_METHOD(showTicketList);
 
 // MARK: - Ticket Methods
-RCT_EXTERN_METHOD(createTicket:(NSString *)subject desc:(NSString *)desc attachments:(NSArray)attachments resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(createTicket:(NSString *)subject desc:(NSString *)desc tags:(NSArray)tags attachments:(NSArray)attachments resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(uploadAttachment:(NSString *)path mimeType:(NSString *)mimeType fileName:(NSString *)file resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNZendesk/RNZendeskBridge.m
+++ b/ios/RNZendesk/RNZendeskBridge.m
@@ -34,7 +34,7 @@ RCT_EXTERN_METHOD(refreshTicket:(NSString *)requestId resultCallback:(RCTRespons
 RCT_EXTERN_METHOD(showTicketList);
 
 // MARK: - Ticket Methods
-RCT_EXTERN_METHOD(createTicket:(NSString *)path resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(createTicket:(NSString *)subject desc:(NSString *)desc resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject);
 
 RCT_EXTERN_METHOD(uploadAttachment:(NSString *)path mimeType:(NSString *)mimeType fileName:(NSString *)file resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,8 @@ export function showTicketList() {
 
 // MARK: - Ticket Methods
 
-export function createTicket(subject: string, desc: string, attachments: string[] = []) {
-  return RNZendesk.createTicket(subject, desc, attachments)
+export function createTicket(subject: string, desc: string, tags: string[] = [], attachments: string[] = []) {
+  return RNZendesk.createTicket(subject, desc, tags, attachments)
 }
 
 export function uploadAttachment(path: string, mimeType: string, fileName: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,6 @@ export function showTicketList() {
 
 // MARK: - Ticket Methods
 
-export function createTicket() {
-  RNZendesk.createTicket()
+export function createTicket(path: string) {
+  RNZendesk.createTicket(path)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,7 @@ export function showTicketList() {
 export function createTicket(path: string) {
   return RNZendesk.createTicket(path)
 }
+
+export function uploadAttachment(path: string, mimeType: string, fileName: string) {
+  return RNZendesk.uploadAttachment(path, mimeType, fileName);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,5 +68,5 @@ export function showTicketList() {
 // MARK: - Ticket Methods
 
 export function createTicket(path: string) {
-  RNZendesk.createTicket(path)
+  return RNZendesk.createTicket(path)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export function showTicketList() {
 
 // MARK: - Ticket Methods
 
-export function createTicket(subject: string, desc: string, attachments: Array<String> = []) {
+export function createTicket(subject: string, desc: string, attachments: string[] = []) {
   return RNZendesk.createTicket(subject, desc, attachments)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,8 @@ export function showTicketList() {
 
 // MARK: - Ticket Methods
 
-export function createTicket(subject: string, desc: string) {
-  return RNZendesk.createTicket(subject, desc)
+export function createTicket(subject: string, desc: string, attachments: Array<String> = []) {
+  return RNZendesk.createTicket(subject, desc, attachments)
 }
 
 export function uploadAttachment(path: string, mimeType: string, fileName: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,3 +64,9 @@ export function showNewTicket(options: NewTicketOptions) {
 export function showTicketList() {
   RNZendesk.showTicketList()
 }
+
+// MARK: - Ticket Methods
+
+export function createTicket() {
+  RNZendesk.createTicket()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,8 @@ export function showTicketList() {
 
 // MARK: - Ticket Methods
 
-export function createTicket(path: string) {
-  return RNZendesk.createTicket(path)
+export function createTicket(subject: string, desc: string) {
+  return RNZendesk.createTicket(subject, desc)
 }
 
 export function uploadAttachment(path: string, mimeType: string, fileName: string) {


### PR DESCRIPTION
This adds the ability to add tickets / upload attachments via Zendesk's [API Providers](https://developer.zendesk.com/embeddables/docs/ios_support_sdk/api_provider_using). I.e we can create tickets by calling the API instead of using the Zendesk UI.